### PR TITLE
Fix video remote labeling

### DIFF
--- a/redbrick/entity/label/bbox.py
+++ b/redbrick/entity/label/bbox.py
@@ -92,6 +92,7 @@ class VideoBoundingBoxEntry:
     ynorm: float
     wnorm: float
     hnorm: float
+    attributes: List[LabelAttribute]
     classname: List[List[str]]
     labelid: str
     trackid: str
@@ -320,6 +321,7 @@ class VideoBoundingBox(BaseBoundingBox):
                 ynorm=label["bbox2d"]["ynorm"],
                 wnorm=label["bbox2d"]["wnorm"],
                 hnorm=label["bbox2d"]["hnorm"],
+                attributes=label["attributes"],
                 classname=label["category"],
                 labelid=label["labelid"],
                 trackid=label["trackid"],
@@ -385,6 +387,7 @@ class VideoBoundingBox(BaseBoundingBox):
         for label in self.labels:
             entry: Dict[Any, Any] = {}
             entry["category"] = label.classname
+            entry["attributes"] = label.attributes
             entry["labelid"] = label.labelid
             entry["bbox2d"] = {
                 "xnorm": label.xnorm,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 setup(
     name="redbrick-sdk",
     url="https://github.com/dereklukacs/redbrick-sdk",
-    version="0.2.15",
+    version="0.2.16",
     description="RedBrick platform python SDK!",
     py_modules=["redbrick"],
     packages=find_packages(),


### PR DESCRIPTION
* add `attributes` field to the `VideoBoundingBoxEntry`
* bump version to 0.2.16