### PR TITLE
Labeling interface changes

### DIFF
--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -36,5 +36,5 @@ Upload
 Labeling
 ----------------------
 .. autoclass:: redbrick.labeling.Labeling
-   :members: get_tasks, put_tasks, get_task_queue, assign_task, move_tasks_to_start
+   :members: get_tasks, put_tasks, get_task_queue, assign_tasks, move_tasks_to_start
    :show-inheritance:

--- a/redbrick/__init__.py
+++ b/redbrick/__init__.py
@@ -25,7 +25,7 @@ from redbrick.utils.logging import logger
 
 from .version_check import version_check
 
-__version__ = "2.7.2"
+__version__ = "2.8.0"
 
 # windows event loop close bug https://github.com/encode/httpx/issues/914#issuecomment-622586610
 try:

--- a/redbrick/common/labeling.py
+++ b/redbrick/common/labeling.py
@@ -33,7 +33,7 @@ class LabelingControllerInterface(ABC):
         stage_name: str,
         task_id: str,
         labels_data: str,
-        labels_path: Optional[str] = None,
+        labels_map: Optional[List[Dict]] = None,
         finished: bool = True,
     ) -> None:
         """Put Labeling results."""
@@ -55,12 +55,11 @@ class LabelingControllerInterface(ABC):
         self,
         org_id: str,
         project_id: str,
-        stage_name: str,
         task_ids: List[str],
         emails: Optional[List[str]] = None,
         current_user: bool = False,
-        refresh: bool = False,
-    ) -> None:
+        refresh: bool = True,
+    ) -> List[Dict]:
         """Assign tasks to specified email or current API key."""
 
     @abstractmethod

--- a/redbrick/export/public.py
+++ b/redbrick/export/public.py
@@ -666,16 +666,14 @@ class Export:
                 self.context.export.task_events,
                 self.org_id,
                 self.project_id,
-                self.output_stage_name if only_ground_truth else None,
+                "END" if only_ground_truth else None,
                 concurrency,
             )
         )
 
+        tasks: List[Dict] = []
         with tqdm.tqdm(my_iter, unit=" datapoints") as progress:
-            tasks = [
-                task
-                for task in progress
-                if (not only_ground_truth or task["currentStageName"] == "END")
-            ]
+            for task in progress:
+                tasks.append(task_event_format(task, users))
 
-        return [task_event_format(task, users) for task in tasks]
+        return tasks

--- a/redbrick/labeling/public.py
+++ b/redbrick/labeling/public.py
@@ -289,13 +289,13 @@ class Labeling:
                 project = redbrick.get_project(...)
 
                 # Set review_result to True if you want to accept the tasks
-                project.review.put_tasks("Review_1", [{taskId: "task1"}], review_result=True)
+                project.review.put_tasks("Review_1", [{taskId: "..."}], review_result=True)
 
                 # Set review_result to False if you want to reject the tasks
-                project.review.put_tasks("Review_1", [{taskId: "task2"}], review_result=False)
+                project.review.put_tasks("Review_1", [{taskId: "..."}], review_result=False)
 
                 # Add labels if you want to accept the tasks with correction
-                project.review.put_tasks("Review_1", [{taskId: "task3", series: [{...}]}])
+                project.review.put_tasks("Review_1", [{taskId: "...", series: [{...}]}])
 
 
         Parameters

--- a/redbrick/project.py
+++ b/redbrick/project.py
@@ -48,8 +48,15 @@ class RBProject:
             if stage["brickName"] == "labelset-output":
                 self.output_stage_name = stage["stageName"]
 
-        self.labeling = Labeling(context, org_id, project_id)
-        self.review = Labeling(context, org_id, project_id, review=True)
+        self.labeling = Labeling(
+            context,
+            org_id,
+            project_id,
+            self.label_stages,
+        )
+        self.review = Labeling(
+            context, org_id, project_id, self.review_stages, review=True
+        )
         self.export = Export(
             context,
             org_id,

--- a/redbrick/upload/public.py
+++ b/redbrick/upload/public.py
@@ -4,9 +4,8 @@ import asyncio
 import os
 import sys
 from copy import deepcopy
-from typing import List, Dict, Optional, Sequence, Set, Union
+from typing import List, Dict, Optional, Set
 import json
-from uuid import uuid4
 
 import aiohttp
 import tenacity
@@ -17,13 +16,9 @@ from redbrick.common.context import RBContext
 from redbrick.common.constants import MAX_CONCURRENCY
 from redbrick.common.enums import StorageMethod
 from redbrick.utils.async_utils import gather_with_concurrency
+from redbrick.utils.upload import process_segmentation_upload, validate_json
 from redbrick.utils.logging import log_error, logger
-from redbrick.utils.files import (
-    NIFTI_FILE_TYPES,
-    download_files,
-    get_file_type,
-    upload_files,
-)
+from redbrick.utils.files import get_file_type, upload_files
 
 
 class Upload:
@@ -128,10 +123,7 @@ class Upload:
         project_label_storage_id: str,
         label_validate: bool,
     ) -> Dict:
-        # pylint: disable=too-many-locals, too-many-branches, too-many-nested-blocks
-        # pylint: disable=import-outside-toplevel, too-many-statements
-        from redbrick.utils.dicom import process_nifti_upload
-
+        # pylint:disable=too-many-locals
         logger.debug(
             f"storage={storage_id}, gt={is_ground_truth}, label_storage={label_storage_id}, "
             + f"project_label_storage={project_label_storage_id}, validate={label_validate}"
@@ -178,172 +170,25 @@ class Upload:
                 presigned_items[idx]["filePath"] for idx in range(len(point["items"]))
             ]
 
-        labels_map: List[Dict] = []
-
-        if (
-            "labelsMap" not in point
-            and point.get("segmentations")
-            and len(point["segmentations"]) == len(point["items"])
-        ):
-            logger.debug("Converting segmentations to labelsMap")
-            point["labelsMap"] = [
-                {"labelName": segmentation, "imageIndex": idx}
-                for idx, segmentation in enumerate(point["segmentations"])
-            ]
-            del point["segmentations"]
-        elif "labelsMap" not in point and point.get("labelsPath"):
-            logger.debug("Converting labelsPath to labelsMap")
-            point["labelsMap"] = [{"labelName": point["labelsPath"], "imageIndex": 0}]
-            del point["labelsPath"]
-
-        labels_map = point.get("labelsMap", []) or []  # type: ignore
-        download_dir = os.path.join(os.path.expanduser("~"), ".redbrickai", "temp")
-        if not os.path.exists(download_dir):
-            logger.debug(f"Creating temp directory: {download_dir}")
-            os.makedirs(download_dir)
-        for volume_index, label_map in enumerate(labels_map):
-            logger.debug(f"Processing label map: {label_map} for volume {volume_index}")
-            if not isinstance(label_map, dict) or not label_map.get("labelName"):
-                logger.debug(
-                    f"Skipping labelMap: {label_map} for volume {volume_index}"
-                )
-                continue
-
-            input_labels_path: Optional[Union[str, List[str]]] = label_map["labelName"]
-            if isinstance(input_labels_path, str) and os.path.isdir(input_labels_path):
-                logger.debug("Label path is a directory")
-                input_labels_path = [
-                    os.path.join(input_labels_path, input_file)
-                    for input_file in os.listdir(input_labels_path)
-                ]
-                if any(
-                    not os.path.isfile(input_path) for input_path in input_labels_path
-                ):
-                    logger.debug("Not all paths are files")
-                    input_labels_path = None
-            elif input_labels_path:
-                if isinstance(input_labels_path, str):
-                    logger.debug("Label path is string")
-                    input_labels_path = [input_labels_path]
-
-                if not input_labels_path or any(
-                    not isinstance(input_path, str) for input_path in input_labels_path
-                ):
-                    input_labels_path = None
-                else:
-                    external_paths = [
-                        input_path
-                        for input_path in input_labels_path
-                        if not os.path.isfile(input_path)
-                    ]
-                    downloaded_paths: Sequence[Optional[str]] = []
-                    if external_paths:
-                        presigned_paths = self.context.export.presign_items(
-                            self.org_id,
-                            label_storage_id,
-                            external_paths,
-                        )
-
-                        download_paths = [
-                            os.path.join(download_dir, f"{uuid4()}.nii")
-                            for _ in range(len(external_paths))
-                        ]
-                        downloaded_paths = await download_files(
-                            list(zip(presigned_paths, download_paths)),
-                            f"Downloading labels for {point.get('name') or point['items'][0]}",
-                            False,
-                        )
-                    if any(not downloaded_path for downloaded_path in downloaded_paths):
-                        input_labels_path = None
-                    else:
-                        input_labels_path = [
-                            input_path
-                            for input_path in input_labels_path
-                            if input_path and os.path.isfile(input_path)
-                        ] + [
-                            downloaded_path
-                            for downloaded_path in downloaded_paths
-                            if downloaded_path
-                        ]
-
-            if input_labels_path:
-                labels = point.get("labels", [])
-                output_labels_path, group_map = process_nifti_upload(
-                    input_labels_path,
-                    set(
-                        label["dicom"]["instanceid"]
-                        for label in labels
-                        if label.get("dicom", {}).get("instanceid")
-                        and (
-                            label.get("volumeindex") is None
-                            or int(label.get("volumeindex")) == volume_index
-                        )
-                    ),
-                    label_validate,
-                )
-
-                for label in labels:
-                    if label.get("dicom", {}).get("instanceid") in group_map:
-                        label["dicom"]["groupids"] = group_map[
-                            label["dicom"]["instanceid"]
-                        ]
-
-                if (
-                    output_labels_path
-                    and not os.path.isfile(output_labels_path)
-                    and label_storage_id != project_label_storage_id
-                ):
-                    presigned_path = self.context.export.presign_items(
-                        self.org_id, label_storage_id, [output_labels_path]
-                    )[0]
-                    output_labels_path = (
-                        await download_files(
-                            [
-                                (
-                                    presigned_path,
-                                    os.path.join(download_dir, f"{uuid4()}.nii"),
-                                )
-                            ],
-                            f"Downloading labels for {point.get('name') or point['items'][0]}",
-                            False,
-                        )
-                    )[0]
-
-                if output_labels_path and os.path.isfile(output_labels_path):
-                    file_type = NIFTI_FILE_TYPES["nii"]
-                    presigned = await self.context.labeling.presign_labels_path(
-                        session,
-                        self.org_id,
-                        self.project_id,
-                        str(uuid4()),
-                        file_type,
-                    )
-                    if (
-                        await upload_files(
-                            [
-                                (
-                                    output_labels_path,
-                                    presigned["presignedUrl"],
-                                    file_type,
-                                )
-                            ],
-                            "Uploading labels for "
-                            + f"{point['name'][:57]}{point['name'][57:] and '...'}",
-                            False,
-                        )
-                    )[0]:
-                        label_map["labelName"] = presigned["filePath"]
-                elif output_labels_path:
-                    label_map["labelName"] = output_labels_path
-                else:
-                    logger.debug("Empty label path")
-                    return {}
-            else:
-                logger.debug("Invalid label files")
-                return {}
+        try:
+            labels_map = await process_segmentation_upload(
+                self.context,
+                session,
+                self.org_id,
+                self.project_id,
+                point,
+                project_label_storage_id,
+                label_storage_id,
+                label_validate,
+            )
+        except ValueError as err:
+            logger.warning(
+                f"Failed to process segmentations: `{err}` for `{point['name']}`"
+            )
+            return {}
 
         return await self._create_datapoint(
-            session, storage_id, point, is_ground_truth, labels_map or None
+            session, storage_id, point, is_ground_truth, labels_map
         )
 
     @staticmethod
@@ -623,47 +468,6 @@ class Upload:
         """
         return self.context.upload.delete_tasks(self.org_id, self.project_id, task_ids)
 
-    async def _validate_json(
-        self, input_data: List[Dict], storage_id: str, concurrency: int
-    ) -> List[Dict]:
-        total_input_data = len(input_data)
-        logger.debug(f"Concurrency: {concurrency} for {total_input_data} items")
-        inputs: List[List[Dict]] = []
-        for batch in range(0, total_input_data, concurrency):
-            inputs.append(input_data[batch : batch + concurrency])
-
-        conn = aiohttp.TCPConnector(limit=MAX_CONCURRENCY)
-        async with aiohttp.ClientSession(connector=conn) as session:
-            coros = [
-                self.context.upload.validate_and_convert_to_import_format(
-                    session, json.dumps(data, separators=(",", ":")), True, storage_id
-                )
-                for data in inputs
-            ]
-            outputs = await gather_with_concurrency(MAX_CONCURRENCY, coros)
-
-        await asyncio.sleep(0.250)  # give time to close ssl connections
-
-        output_data: List[Dict] = []
-        for idx, (inp, out) in enumerate(zip(inputs, outputs)):
-            if not out.get("isValid"):
-                logger.debug(f"Error for batch: {idx}")
-                logger.warning(
-                    out.get(
-                        "error",
-                        "Error: Invalid format\n"
-                        + "Docs: https://docs.redbrickai.com/python-sdk/reference"
-                        + "/annotation-format-nifti#items-json",
-                    )
-                )
-                return []
-
-            output_data.extend(
-                json.loads(out["converted"]) if out.get("converted") else inp
-            )
-
-        return output_data
-
     async def generate_items_list(
         self,
         items_list: List[List[str]],
@@ -766,7 +570,7 @@ class Upload:
 
             loop = asyncio.get_event_loop()
             file_data = loop.run_until_complete(
-                self._validate_json(file_data, storage_id, concurrency)
+                validate_json(self.context, file_data, storage_id, concurrency)
             )
             if not file_data:
                 continue

--- a/redbrick/utils/upload.py
+++ b/redbrick/utils/upload.py
@@ -1,0 +1,231 @@
+"""Upload implementations."""
+import os
+import json
+import asyncio
+from uuid import uuid4
+from typing import List, Dict, Union, Optional, Sequence
+
+import aiohttp
+from redbrick.common.context import RBContext
+from redbrick.utils.files import NIFTI_FILE_TYPES, download_files, upload_files
+
+from redbrick.utils.logging import logger
+from redbrick.common.constants import MAX_CONCURRENCY
+from redbrick.utils.async_utils import gather_with_concurrency
+
+
+async def validate_json(
+    context: RBContext, input_data: List[Dict], storage_id: str, concurrency: int
+) -> List[Dict]:
+    """Validate and convert to import format."""
+    total_input_data = len(input_data)
+    logger.debug(f"Concurrency: {concurrency} for {total_input_data} items")
+    inputs: List[List[Dict]] = []
+    for batch in range(0, total_input_data, concurrency):
+        inputs.append(input_data[batch : batch + concurrency])
+
+    conn = aiohttp.TCPConnector(limit=MAX_CONCURRENCY)
+    async with aiohttp.ClientSession(connector=conn) as session:
+        coros = [
+            context.upload.validate_and_convert_to_import_format(
+                session, json.dumps(data, separators=(",", ":")), True, storage_id
+            )
+            for data in inputs
+        ]
+        outputs = await gather_with_concurrency(MAX_CONCURRENCY, coros)
+
+    await asyncio.sleep(0.250)  # give time to close ssl connections
+
+    output_data: List[Dict] = []
+    for idx, (inp, out) in enumerate(zip(inputs, outputs)):
+        if not out.get("isValid"):
+            logger.debug(f"Error for batch: {idx}")
+            logger.warning(
+                out.get(
+                    "error",
+                    "Error: Invalid format\n"
+                    + "Docs: https://docs.redbrickai.com/python-sdk/reference"
+                    + "/annotation-format-nifti#items-json",
+                )
+            )
+            return []
+
+        output_data.extend(
+            json.loads(out["converted"]) if out.get("converted") else inp
+        )
+
+    return output_data
+
+
+async def process_segmentation_upload(
+    context: RBContext,
+    session: aiohttp.ClientSession,
+    org_id: str,
+    project_id: str,
+    task: Dict,
+    project_label_storage_id: str,
+    label_storage_id: str,
+    label_validate: bool,
+):
+    """Process segmentation upload."""
+    # pylint: disable=too-many-branches, too-many-locals, too-many-statements
+    # pylint: disable=import-outside-toplevel
+    from redbrick.utils.dicom import process_nifti_upload
+
+    labels_map: List[Dict] = []
+
+    if (
+        "labelsMap" not in task
+        and task.get("segmentations")
+        and len(task["segmentations"]) == len(task["items"])
+    ):
+        logger.debug("Converting segmentations to labelsMap")
+        task["labelsMap"] = [
+            {"labelName": segmentation, "imageIndex": idx}
+            for idx, segmentation in enumerate(task["segmentations"])
+        ]
+        del task["segmentations"]
+    elif "labelsMap" not in task and task.get("labelsPath"):
+        logger.debug("Converting labelsPath to labelsMap")
+        task["labelsMap"] = [{"labelName": task["labelsPath"], "imageIndex": 0}]
+        del task["labelsPath"]
+
+    labels_map = task.get("labelsMap", []) or []  # type: ignore
+    download_dir = os.path.join(os.path.expanduser("~"), ".redbrickai", "temp")
+    if not os.path.exists(download_dir):
+        logger.debug(f"Creating temp directory: {download_dir}")
+        os.makedirs(download_dir)
+    for volume_index, label_map in enumerate(labels_map):
+        logger.debug(f"Processing label map: {label_map} for volume {volume_index}")
+        if not isinstance(label_map, dict) or not label_map.get("labelName"):
+            logger.debug(f"Skipping labelMap: {label_map} for volume {volume_index}")
+            continue
+
+        input_labels_path: Optional[Union[str, List[str]]] = label_map["labelName"]
+        if isinstance(input_labels_path, str) and os.path.isdir(input_labels_path):
+            logger.debug("Label path is a directory")
+            input_labels_path = [
+                os.path.join(input_labels_path, input_file)
+                for input_file in os.listdir(input_labels_path)
+            ]
+            if any(not os.path.isfile(input_path) for input_path in input_labels_path):
+                logger.debug("Not all paths are files")
+                input_labels_path = None
+        elif input_labels_path:
+            if isinstance(input_labels_path, str):
+                logger.debug("Label path is string")
+                input_labels_path = [input_labels_path]
+
+            if not input_labels_path or any(
+                not isinstance(input_path, str) for input_path in input_labels_path
+            ):
+                input_labels_path = None
+            else:
+                external_paths = [
+                    input_path
+                    for input_path in input_labels_path
+                    if not os.path.isfile(input_path)
+                ]
+                downloaded_paths: Sequence[Optional[str]] = []
+                if external_paths:
+                    presigned_paths = context.export.presign_items(
+                        org_id,
+                        label_storage_id,
+                        external_paths,
+                    )
+
+                    download_paths = [
+                        os.path.join(download_dir, f"{uuid4()}.nii")
+                        for _ in range(len(external_paths))
+                    ]
+                    downloaded_paths = await download_files(
+                        list(zip(presigned_paths, download_paths)),
+                        f"Downloading labels for {task.get('name') or task['items'][0]}",
+                        False,
+                    )
+                if any(not downloaded_path for downloaded_path in downloaded_paths):
+                    input_labels_path = None
+                else:
+                    input_labels_path = [
+                        input_path
+                        for input_path in input_labels_path
+                        if input_path and os.path.isfile(input_path)
+                    ] + [
+                        downloaded_path
+                        for downloaded_path in downloaded_paths
+                        if downloaded_path
+                    ]
+
+        if input_labels_path:
+            labels = task.get("labels", [])
+            output_labels_path, group_map = process_nifti_upload(
+                input_labels_path,
+                set(
+                    label["dicom"]["instanceid"]
+                    for label in labels
+                    if label.get("dicom", {}).get("instanceid")
+                    and (
+                        label.get("volumeindex") is None
+                        or int(label.get("volumeindex")) == volume_index
+                    )
+                ),
+                label_validate,
+            )
+
+            for label in labels:
+                if label.get("dicom", {}).get("instanceid") in group_map:
+                    label["dicom"]["groupids"] = group_map[label["dicom"]["instanceid"]]
+
+            if (
+                output_labels_path
+                and not os.path.isfile(output_labels_path)
+                and label_storage_id != project_label_storage_id
+            ):
+                presigned_path = context.export.presign_items(
+                    org_id, label_storage_id, [output_labels_path]
+                )[0]
+                output_labels_path = (
+                    await download_files(
+                        [
+                            (
+                                presigned_path,
+                                os.path.join(download_dir, f"{uuid4()}.nii"),
+                            )
+                        ],
+                        f"Downloading labels for {task.get('name') or task['items'][0]}",
+                        False,
+                    )
+                )[0]
+
+            if output_labels_path and os.path.isfile(output_labels_path):
+                file_type = NIFTI_FILE_TYPES["nii"]
+                presigned = await context.labeling.presign_labels_path(
+                    session,
+                    org_id,
+                    project_id,
+                    str(uuid4()),
+                    file_type,
+                )
+                if (
+                    await upload_files(
+                        [
+                            (
+                                output_labels_path,
+                                presigned["presignedUrl"],
+                                file_type,
+                            )
+                        ],
+                        "Uploading labels for "
+                        + f"{task['name'][:57]}{task['name'][57:] and '...'}",
+                        False,
+                    )
+                )[0]:
+                    label_map["labelName"] = presigned["filePath"]
+            elif output_labels_path:
+                label_map["labelName"] = output_labels_path
+            else:
+                raise ValueError("Empty label path")
+        else:
+            raise ValueError("Invalid label files")
+
+    return labels_map or []


### PR DESCRIPTION
## Added

1. `Labeling.assign_tasks`
- Assign multiple tasks at once in the stage that they are currently in

## Changed

1. `Labeling.put_tasks`
- All arguments except `stage_name` and `tasks` are keyword-only.
- `finalize` boolean indicates whether to submit or save the task as draft in the label stage
- `review_result` boolean indicates whether to accept or reject all tasks in the review stage
2. `Labeling.get_task_queue`
- Get tasks in users' queue based on their email

## Removed

1. `Labeling.assign_task`
- In favour of `Labeling.assign_tasks`