### PR TITLE
allow updating task items

### DIFF
--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -30,7 +30,7 @@ Export
 Upload
 ----------------------
 .. autoclass:: redbrick.upload.Upload
-   :members: create_datapoints, delete_tasks
+   :members: create_datapoints, delete_tasks, update_task_items
    :show-inheritance:
 
 Labeling

--- a/redbrick/__init__.py
+++ b/redbrick/__init__.py
@@ -25,7 +25,7 @@ from redbrick.utils.logging import logger
 
 from .version_check import version_check
 
-__version__ = "2.9.1"
+__version__ = "2.9.2"
 
 # windows event loop close bug https://github.com/encode/httpx/issues/914#issuecomment-622586610
 try:

--- a/redbrick/cli/command/upload.py
+++ b/redbrick/cli/command/upload.py
@@ -322,6 +322,8 @@ but may increase the upload time.""",
                     self.args.ground_truth,
                     label_storage_id,
                     self.args.label_validate,
+                    self.args.concurrency,
+                    False,
                 )
             )
 

--- a/redbrick/common/upload.py
+++ b/redbrick/common/upload.py
@@ -32,6 +32,19 @@ class UploadControllerInterface(ABC):
         """
 
     @abstractmethod
+    async def update_items_async(
+        self,
+        aio_client: aiohttp.ClientSession,
+        org_id: str,
+        project_id: str,
+        storage_id: str,
+        task_id: str,
+        items: List[str],
+        series_info: Optional[List[Dict]] = None,
+    ) -> Dict:
+        """Update items in a datapoint."""
+
+    @abstractmethod
     def items_upload_presign(
         self, org_id: str, project_id: str, files: List[str], file_type: List[str]
     ) -> List[Dict[Any, Any]]:

--- a/redbrick/repo/upload.py
+++ b/redbrick/repo/upload.py
@@ -86,6 +86,53 @@ class UploadRepo(UploadControllerInterface):
         )
         return response.get("createDatapoint", {})
 
+    async def update_items_async(
+        self,
+        aio_client: aiohttp.ClientSession,
+        org_id: str,
+        project_id: str,
+        storage_id: str,
+        task_id: str,
+        items: List[str],
+        series_info: Optional[List[Dict]] = None,
+    ) -> Dict:
+        """Update items in a datapoint."""
+        query_string = """
+            mutation updateTaskItems(
+                $orgId: UUID!
+                $projectId: UUID!
+                $storageId: UUID!
+                $taskId: UUID!
+                $items: [String!]!
+                $seriesInfo: [SeriesInfoInput!]
+            ) {
+                updateTaskItems(
+                    orgId: $orgId
+                    projectId: $projectId
+                    storageId: $storageId
+                    taskId: $taskId
+                    items: $items
+                    seriesInfo: $seriesInfo
+                ) {
+                    ok
+                    message
+                }
+            }
+        """
+
+        query_variables = {
+            "orgId": org_id,
+            "projectId": project_id,
+            "storageId": storage_id,
+            "taskId": task_id,
+            "items": items,
+            "seriesInfo": series_info,
+        }
+        response = await self.client.execute_query_async(
+            aio_client, query_string, query_variables
+        )
+        return response.get("updateTaskItems", {})
+
     def items_upload_presign(
         self, org_id: str, project_id: str, files: List[str], file_type: List[str]
     ) -> List[Dict[Any, Any]]:


### PR DESCRIPTION
`Upload.update_task_items`

```python
    (
        storage_id: str,
        points: List[Dict],
        concurrency: int = 50,
    ) -> List[Dict]:
        """
        Update items paths for the mentioned task ids.
        .. code:: python
            project = redbrick.get_project(org_id, project_id, api_key, url)
            points = [
                {
                    "taskId": "...",
                    "series": [
                        {
                            "items": "...",
                        }
                    ]
                }
            ]
            project.upload.update_task_items(storage_id, points)
        Parameters
        --------------
        storage_id: str
            Your RedBrick AI external storage_id. This can be found under the Storage Tab
            on the RedBrick AI platform. To directly upload images to rbai,
            use redbrick.StorageMathod.REDBRICK.
        points: List[Dict]
            List of objects with `taskId` and `series`, where `series` contains
            a list of `items` paths to be updated for the task.
        concurrency: int = 50
        Returns
        -------------
        List[Dict]
            List of task objects with key `response` if successful, else `error`
        Note
        ----------
            1. If doing direct upload, please use ``redbrick.StorageMethod.REDBRICK``
            as the storage id. Your items path must be a valid path to a locally stored image.
        """
```