### PR TITLE
Export enhancements

### DIFF
--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -30,7 +30,7 @@ Project
 Export
 ----------------------
 .. autoclass:: redbrick.export.Export
-   :members: export_tasks, list_tasks, get_task_events
+   :members: export_tasks, list_tasks, get_task_events, get_active_time
    :show-inheritance:
 
 Upload

--- a/docs/sdk.rst
+++ b/docs/sdk.rst
@@ -12,7 +12,7 @@ RedBrick
 Organization
 ----------------------
 .. automodule:: redbrick.organization.RBOrganization
-   :members: name, org_id, create_workspace, create_project, labeling_time, create_taxonomy_new, get_taxonomy, update_taxonomy
+   :members: name, org_id, create_workspace, create_project, labeling_time, create_taxonomy, get_taxonomy, update_taxonomy
    :show-inheritance:
 
 Workspace
@@ -30,7 +30,7 @@ Project
 Export
 ----------------------
 .. autoclass:: redbrick.export.Export
-   :members: export_tasks, list_tasks, get_task_events, search_tasks, redbrick_nifti
+   :members: export_tasks, list_tasks, get_task_events
    :show-inheritance:
 
 Upload
@@ -42,5 +42,5 @@ Upload
 Labeling
 ----------------------
 .. autoclass:: redbrick.labeling.Labeling
-   :members: put_tasks, assign_tasks, move_tasks_to_start, get_tasks, get_task_queue
+   :members: put_tasks, assign_tasks, move_tasks_to_start
    :show-inheritance:

--- a/redbrick/__init__.py
+++ b/redbrick/__init__.py
@@ -28,7 +28,7 @@ from redbrick.utils.common_utils import config_migration
 
 from .version_check import version_check
 
-__version__ = "2.12.10a1"
+__version__ = "2.13.0a1"
 
 # windows event loop close bug https://github.com/encode/httpx/issues/914#issuecomment-622586610
 try:

--- a/redbrick/cli/entity/cache.py
+++ b/redbrick/cli/entity/cache.py
@@ -127,6 +127,46 @@ class CLICache:
             file_.write(data)
         return cache_hash
 
+    def remove_data(self, name: str, fixed_cache: bool = False) -> None:
+        """Remove cache data."""
+        cache_file = self.cache_path(name, fixed_cache=fixed_cache)
+        if os.path.isfile(cache_file):
+            os.remove(cache_file)
+
+    def get_entity(
+        self, name: str, fixed_cache: bool = False
+    ) -> Optional[Union[str, Dict, List]]:
+        """Get cache entity."""
+        cache_file = self.cache_path(*self._task_path(name), fixed_cache=fixed_cache)
+        with open(cache_file, "r", encoding="utf-8") as file_:
+            data = json.load(file_)
+        return data
+
+    def set_entity(
+        self, name: str, entity: Union[str, Dict, List], fixed_cache: bool = False
+    ) -> None:
+        """Set cache entity."""
+        cache_file = self.cache_path(*self._task_path(name), fixed_cache=fixed_cache)
+        with open(cache_file, "w", encoding="utf-8") as file_:
+            json.dump(entity, file_, separators=(",", ":"))
+
+    def remove_entity(self, name: str, fixed_cache: bool = False) -> None:
+        """Remove cache entity."""
+        cache_file = self.cache_path(*self._task_path(name), fixed_cache=fixed_cache)
+        if os.path.isfile(cache_file):
+            os.remove(cache_file)
+
+    def _task_path(self, task_id: str) -> List[str]:
+        """Get task dir from id."""
+        return [
+            task_id[6:8],
+            task_id[11:13],
+            task_id[16:18],
+            task_id[21:23],
+            task_id[34:36],
+            task_id,
+        ]
+
     def clear_cache(self, all_caches: bool = False) -> None:
         """Clear project cache."""
         if not self.exists:

--- a/redbrick/common/export.py
+++ b/redbrick/common/export.py
@@ -18,6 +18,8 @@ class TaskFilterParams(TypedDict, total=False):
     reviewState: ReviewStates
     benchmark: bool
     recentlyCompleted: bool
+    completedAtFrom: str
+    completedAtTo: str
 
 
 class ExportControllerInterface(ABC):

--- a/redbrick/common/export.py
+++ b/redbrick/common/export.py
@@ -91,3 +91,15 @@ class ExportControllerInterface(ABC):
         after: Optional[str] = None,
     ) -> Tuple[List[Dict], Optional[str]]:
         """Get task events."""
+
+    @abstractmethod
+    def active_time(
+        self,
+        org_id: str,
+        project_id: str,
+        stage_name: str,
+        task_id: Optional[str] = None,
+        first: int = 100,
+        after: Optional[str] = None,
+    ) -> Tuple[List[Dict], Optional[str]]:
+        """Get task active time."""

--- a/redbrick/common/project.py
+++ b/redbrick/common/project.py
@@ -63,18 +63,6 @@ class ProjectRepoInterface(ABC):
         self,
         org_id: str,
         name: str,
-        categories: List[Dict],
-        attributes: Optional[List[Dict]],
-        task_categories: Optional[List[Dict]],
-        task_attributes: Optional[List[Dict]],
-    ) -> bool:
-        """Create taxonomy."""
-
-    @abstractmethod
-    def create_taxonomy_new(
-        self,
-        org_id: str,
-        name: str,
         study_classify: Optional[List[Dict]],
         series_classify: Optional[List[Dict]],
         instance_classify: Optional[List[Dict]],

--- a/redbrick/export/public.py
+++ b/redbrick/export/public.py
@@ -2,7 +2,7 @@
 import asyncio
 import re
 import shutil
-from typing import List, Dict, Optional, Set, Tuple, Any
+from typing import Iterator, List, Dict, Optional, Set, Tuple, Any
 from functools import partial
 import os
 import json
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 import aiohttp
 import tqdm  # type: ignore
 
-from redbrick.common.constants import MAX_CONCURRENCY, MAX_FILE_BATCH_SIZE
+from redbrick.common.constants import MAX_CONCURRENCY
 from redbrick.common.context import RBContext
 from redbrick.common.enums import ReviewStates, TaskFilters, TaskStates
 from redbrick.common.export import TaskFilterParams
@@ -71,18 +71,16 @@ class Export:
         presign_items: bool = False,
         with_consensus: bool = False,
         task_id: Optional[str] = None,
-    ) -> Tuple[List[Dict], Dict]:
+    ) -> Iterator[Dict]:
         # pylint: disable=too-many-locals
-        taxonomy = self.context.project.get_taxonomy(
-            self.org_id, tax_id=None, name=self.taxonomy_name
-        )
         if task_id:
             logger.info(f"Fetching task: {task_id}")
             val = self.context.export.get_datapoint_latest(
                 self.org_id, self.project_id, task_id, presign_items, with_consensus
             )
             task = parse_entry_latest(val)
-            return ([task] if task else []), taxonomy
+            yield task
+            return
 
         stage_name = "END" if only_ground_truth else None
         my_iter = PaginationIterator(
@@ -100,10 +98,6 @@ class Export:
             concurrency,
         )
 
-        datapoint_count = self.context.export.datapoints_in_project(
-            self.org_id, self.project_id, stage_name
-        )
-
         logger.info(
             f"Downloading {'groundtruth' if only_ground_truth else 'all'} tasks"
             + (
@@ -113,21 +107,10 @@ class Export:
             )
         )
 
-        with tqdm.tqdm(my_iter, unit=" datapoints", total=datapoint_count) as progress:
-            datapoints = []
-            for val in progress:
-                task = parse_entry_latest(val)
-                if task:
-                    datapoints.append(task)
-            try:
-                disable = progress.disable
-                progress.disable = False
-                progress.update(datapoint_count - progress.n)
-                progress.disable = disable
-            except Exception:  # pylint: disable=broad-except
-                pass
-
-        return datapoints, taxonomy
+        for val in my_iter:
+            task = parse_entry_latest(val)
+            if task:
+                yield task
 
     async def _get_input_labels(self, dp_ids: List[str]) -> List[Dict]:
         conn = aiohttp.TCPConnector()
@@ -262,39 +245,24 @@ class Export:
             else []
         )
 
-    async def _download_tasks(
+    async def _download_task(
         self,
-        tasks: List[Dict],
-        storage_ids: List[str],
+        original_task: Dict,
+        storage_id: str,
         taxonomy: Dict,
-        export_dir: str,
+        image_dir: str,
         dcm_to_nii: bool,
         rt_struct: bool,
-        is_tax_v2: bool,
-        concurrency: int = 5,
-    ) -> List[Dict]:
+    ) -> Dict:
         # pylint: disable=too-many-locals, import-outside-toplevel, too-many-nested-blocks
-
-        images_dir = os.path.join(export_dir, "images")
-        os.makedirs(images_dir, exist_ok=True)
-
-        downloaded_tasks = await gather_with_concurrency(
-            min(concurrency, MAX_FILE_BATCH_SIZE),
-            [
-                self._download_task(
-                    task, storage_id, images_dir, taxonomy, rt_struct, is_tax_v2
-                )
-                for task, storage_id in zip(tasks, storage_ids)
-            ],
-            progress_bar_name="Downloading images",
-            keep_progress_bar=False,
+        task, series_dirs = await self._download_task_items(
+            original_task, storage_id, image_dir, taxonomy, rt_struct
         )
-        tasks = [task for task, _ in downloaded_tasks]
 
-        logger.info(f"Exported images to: {images_dir}")
+        logger.info(f"Exported images to: {image_dir}")
 
         if not dcm_to_nii:
-            return tasks
+            return task
 
         import numpy as np  # type: ignore
         import nibabel as nb  # type: ignore
@@ -316,79 +284,80 @@ class Export:
             )
             + r")(\.gz)?$"
         )
-        for task, series_dirs in downloaded_tasks:
-            task_series = Export._get_task_series(task)
-            if not task_series or len(task_series) != len(series_dirs):
-                continue
-            for series, series_dir in zip(task_series, series_dirs):
-                items = (
-                    [series["items"]]
-                    if isinstance(series["items"], str)
-                    else series["items"]
+
+        task_series = Export._get_task_series(task)
+        if not task_series or len(task_series) != len(series_dirs):
+            return task
+
+        for series, series_dir in zip(task_series, series_dirs):
+            items = (
+                [series["items"]]
+                if isinstance(series["items"], str)
+                else series["items"]
+            )
+            if (
+                dcm_to_nii
+                and len(items) > 1
+                and not any(
+                    re.search(dcm_ext, item.split("?", 1)[0].rstrip("/"))
+                    for item in items
                 )
-                if (
-                    dcm_to_nii
-                    and len(items) > 1
-                    and not any(
-                        re.search(dcm_ext, item.split("?", 1)[0].rstrip("/"))
-                        for item in items
+            ):
+                logger.info(f"Converting {task['taskId']} image to nifti")
+                try:
+                    nii_img = dicom_series_to_nifti(
+                        series_dir, uniquify_path(series_dir + ".nii.gz")
                     )
-                ):
-                    logger.info(f"Converting {task['taskId']} image to nifti")
+                except Exception as err:  # pylint: disable=broad-except
+                    logger.warning(
+                        f"Task {task['taskId']} : Failed to convert {series_dir} - {err}"
+                    )
+                    return task
+
+                series["items"] = nii_img["NII_FILE"]
+                if series.get("segmentations"):
+                    logger.debug(f"{task['taskId']} matching headers")
                     try:
-                        nii_img = dicom_series_to_nifti(
-                            series_dir, uniquify_path(series_dir + ".nii.gz")
+                        nii_seg = nb.load(  # type: ignore
+                            os.path.abspath(
+                                series["segmentations"]
+                                if isinstance(series["segmentations"], str)
+                                else series["segmentations"][0]
+                            )
                         )
+                        imgh = nii_img["NII"].header
+                        segh = nii_seg.header
+                        if not (
+                            imgh.get_data_shape() == segh.get_data_shape()  # type: ignore
+                            and imgh.get_data_offset() == segh.get_data_offset()  # type: ignore
+                            and np.array_equal(
+                                imgh.get_best_affine(), segh.get_best_affine()  # type: ignore
+                            )
+                            and np.array_equal(
+                                imgh.get_qform(), segh.get_qform()  # type: ignore
+                            )
+                            and np.array_equal(
+                                imgh.get_sform(), segh.get_sform()  # type: ignore
+                            )
+                        ):
+                            logger.warning(
+                                f"Task: {task['taskId']} : Headers of converted "
+                                + "nifti image and segmentation do not match."
+                            )
                     except Exception as err:  # pylint: disable=broad-except
                         logger.warning(
-                            f"Task {task['taskId']} : Failed to convert {series_dir} - {err}"
+                            f"Task {task['taskId']} : Failed to match headers - {err}"
                         )
-                        continue
-                    series["items"] = nii_img["NII_FILE"]
-                    if series.get("segmentations"):
-                        logger.debug(f"{task['taskId']} matching headers")
-                        try:
-                            nii_seg = nb.load(  # type: ignore
-                                os.path.abspath(
-                                    series["segmentations"]
-                                    if isinstance(series["segmentations"], str)
-                                    else series["segmentations"][0]
-                                )
-                            )
-                            imgh = nii_img["NII"].header
-                            segh = nii_seg.header
-                            if not (
-                                imgh.get_data_shape() == segh.get_data_shape()  # type: ignore
-                                and imgh.get_data_offset() == segh.get_data_offset()  # type: ignore
-                                and np.array_equal(
-                                    imgh.get_best_affine(), segh.get_best_affine()  # type: ignore
-                                )
-                                and np.array_equal(
-                                    imgh.get_qform(), segh.get_qform()  # type: ignore
-                                )
-                                and np.array_equal(
-                                    imgh.get_sform(), segh.get_sform()  # type: ignore
-                                )
-                            ):
-                                logger.warning(
-                                    f"Task: {task['taskId']} : Headers of converted "
-                                    + "nifti image and segmentation do not match."
-                                )
-                        except Exception as err:  # pylint: disable=broad-except
-                            logger.warning(
-                                f"Task {task['taskId']} : Failed to match headers - {err}"
-                            )
 
-        return tasks
+        return task
 
-    async def _download_task(
+    async def _download_task_items(
         self,
         task: Dict,
         storage_id: str,
         parent_dir: str,
         taxonomy: Dict,
         rt_struct: bool,
-        is_tax_v2: bool,
     ) -> Tuple[Dict, List[str]]:
         # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         path_pattern = re.compile(r"[^\w.]+")
@@ -499,7 +468,7 @@ class Export:
                     for idx, series in enumerate(sub_task.get("series", []) or []):
                         series["items"] = series_items[idx]
 
-                if is_tax_v2 and rt_struct:
+                if taxonomy.get("isNew") and rt_struct:
                     # pylint: disable=import-outside-toplevel
                     from redbrick.utils.dicom import convert_nii_to_rtstruct
 
@@ -740,27 +709,14 @@ class Export:
                     )
                     index += 1
 
-    def export_nifti_label_data(
-        self,
-        datapoints: List[Dict],
-        concurrency: int,
-        taxonomy: Dict,
-        export_dir: str,
-        nifti_dir: str,
-        old_format: bool,
-        no_consensus: bool,
-        with_files: bool,
-        dicom_to_nifti: bool,
-        png_mask: bool,
-        rt_struct: bool,
-    ) -> Tuple[List[Dict], Dict]:
-        """Export nifti label maps."""
-        # pylint: disable=too-many-locals
+    def preprocess_export(
+        self, taxonomy: Dict, get_color_map: bool
+    ) -> Tuple[Dict, Dict]:
+        """Get classMap and colorMap."""
         class_map: Dict = {}
         color_map: Dict = {}
-        is_tax_v2 = bool(taxonomy.get("isNew"))
-        if png_mask:
-            if is_tax_v2:
+        if get_color_map:
+            if bool(taxonomy.get("isNew")):
                 object_types = taxonomy.get("objectTypes", []) or []
                 for object_type in object_types:
                     if object_type["labelType"] == "SEGMENTATION":
@@ -780,45 +736,62 @@ class Export:
                     taxonomy.get("colorMap"),
                 )
                 class_map = color_map
-        os.makedirs(nifti_dir, exist_ok=True)
-        loop = asyncio.get_event_loop()
-        tasks = loop.run_until_complete(
-            gather_with_concurrency(
-                min(concurrency, MAX_FILE_BATCH_SIZE),
-                [
-                    self.process_labels(
-                        datapoint,
-                        nifti_dir,
-                        color_map,
-                        old_format,
-                        no_consensus,
-                        png_mask,
-                        is_tax_v2,
-                    )
-                    for datapoint in datapoints
-                ],
-                "Processing labels",
-            )
-        )
 
+        return class_map, color_map
+
+    async def export_nifti_label_data(
+        self,
+        datapoint: Dict,
+        taxonomy: Dict,
+        task_file: str,
+        image_dir: str,
+        segmentation_dir: str,
+        old_format: bool,
+        no_consensus: bool,
+        color_map: Dict,
+        with_files: bool,
+        dicom_to_nifti: bool,
+        png_mask: bool,
+        rt_struct: bool,
+        get_task: bool,
+    ) -> Optional[Dict]:
+        """Export nifti label maps."""
+        # pylint: disable=too-many-locals
+        task = await self.process_labels(
+            datapoint,
+            segmentation_dir,
+            color_map,
+            old_format,
+            no_consensus,
+            png_mask,
+            bool(taxonomy.get("isNew")),
+        )
         if with_files or rt_struct:
             try:
-                loop.run_until_complete(
-                    self._download_tasks(
-                        tasks,
-                        [datapoint["storageId"] for datapoint in datapoints],
-                        taxonomy,
-                        export_dir,
-                        dicom_to_nifti,
-                        rt_struct,
-                        is_tax_v2,
-                        concurrency,
-                    )
+                task = await self._download_task(
+                    task,
+                    datapoint["storageId"],
+                    taxonomy,
+                    image_dir,
+                    dicom_to_nifti,
+                    rt_struct,
                 )
             except Exception as err:  # pylint: disable=broad-except
                 log_error(f"Failed to download files: {err}")
 
-        return tasks, class_map
+        if os.path.isfile(task_file):
+            with open(task_file, "rb+") as task_file_:
+                task_file_.seek(-1, 2)
+                task_file_.write(
+                    b"," + json.dumps(task, indent=2).encode("utf-8") + b"]"
+                )
+        else:
+            with open(task_file, "wb") as task_file_:
+                task_file_.write(
+                    b"[" + json.dumps(task, indent=2).encode("utf-8") + b"]"
+                )
+
+        return task if get_task else None
 
     def export_tasks(
         self,
@@ -834,7 +807,7 @@ class Export:
         png: bool = False,
         rt_struct: bool = False,
         destination: Optional[str] = None,
-    ) -> List[Dict]:
+    ) -> Iterator[Dict]:
         """Export annotation data.
 
         Meta-data and category information returned as an Object. Segmentations are written to
@@ -889,7 +862,7 @@ class Export:
 
         Returns
         -----------
-        List[Dict]
+        Iterator[Dict]
             Datapoint and labels in RedBrick AI format. See
             https://docs.redbrickai.com/python-sdk/reference/annotation-format
         """
@@ -899,7 +872,31 @@ class Export:
             no_consensus if no_consensus is not None else not self.consensus_enabled
         )
 
-        datapoints, taxonomy = self._get_raw_data_latest(
+        taxonomy = self.context.project.get_taxonomy(
+            self.org_id, tax_id=None, name=self.taxonomy_name
+        )
+
+        # Create output directory
+        destination = destination or self.project_id
+
+        task_file = os.path.join(destination, "tasks.json")
+
+        image_dir = os.path.join(destination, "images")
+        os.makedirs(image_dir, exist_ok=True)
+
+        segmentation_dir = os.path.join(destination, "segmentations")
+        os.makedirs(segmentation_dir, exist_ok=True)
+
+        logger.info(f"Saving NIfTI files to {destination} directory")
+        class_map, color_map = self.preprocess_export(taxonomy, png)
+
+        if png:
+            with open(
+                os.path.join(destination, "class_map.json"), "w", encoding="utf-8"
+            ) as classes_file:
+                json.dump(class_map, classes_file, indent=2)
+
+        datapoints = self._get_raw_data_latest(
             concurrency,
             False if task_id else only_ground_truth,
             None if task_id else from_timestamp,
@@ -910,143 +907,29 @@ class Export:
             task_id,
         )
 
-        if task_id:
-            datapoints = [
-                datapoint for datapoint in datapoints if datapoint["taskId"] == task_id
-            ]
+        if os.path.isfile(task_file):
+            os.remove(task_file)
 
-        # Create output directory
-        destination = destination or self.project_id
-        nifti_dir = os.path.join(destination, "nifti")
-        os.makedirs(nifti_dir, exist_ok=True)
-        logger.info(f"Saving NIfTI files to {destination} directory")
-        tasks, class_map = self.export_nifti_label_data(
-            datapoints,
-            concurrency,
-            taxonomy,
-            destination,
-            nifti_dir,
-            old_format,
-            no_consensus,
-            with_files,
-            dicom_to_nifti,
-            png,
-            rt_struct,
-        )
-        with open(
-            os.path.join(destination, "tasks.json"), "w", encoding="utf-8"
-        ) as tasks_file:
-            json.dump(tasks, tasks_file, indent=2)
-
-        if png:
-            with open(
-                os.path.join(destination, "class_map.json"), "w", encoding="utf-8"
-            ) as classes_file:
-                json.dump(class_map, classes_file, indent=2)
-
-        return tasks
-
-    def redbrick_nifti(
-        self,
-        only_ground_truth: bool = True,
-        concurrency: int = 10,
-        task_id: Optional[str] = None,
-        from_timestamp: Optional[float] = None,
-        old_format: bool = False,
-        no_consensus: Optional[bool] = None,
-        png: bool = False,
-    ) -> List[Dict]:
-        """
-        .. admonition:: Deprecation Notice
-
-            .. deprecated:: 2.11.0
-
-            Use :obj:`~redbrick.export.Export.export_tasks` instead.
-
-        Alias to export_tasks method.
-        """
-        logger.warning(
-            "`Export.redbrick_nifti` method has been deprecated and will be removed "
-            + "in a future release. Please use `Export.export_tasks` method instead."
-        )
-        return self.export_tasks(
-            only_ground_truth,
-            concurrency,
-            task_id=task_id,
-            from_timestamp=from_timestamp,
-            old_format=old_format,
-            no_consensus=no_consensus,
-            png=png,
-        )
-
-    def search_tasks(
-        self,
-        only_ground_truth: bool = True,
-        concurrency: int = 10,
-        name: Optional[str] = None,
-    ) -> List[Dict]:
-        """
-        .. admonition:: Deprecation Notice
-
-            .. deprecated:: 2.11.0
-
-            Use :obj:`~redbrick.export.Export.list_tasks` instead.
-
-        Search tasks by ``task_id`` or ``name`` in any stage of your project workflow.
-        This function returns minimal meta-data about the queried tasks.
-
-        >>> project = redbrick.get_project(org_id, project_id, api_key, url)
-        >>> result = project.export.search_tasks()
-
-        Parameters
-        -----------
-        only_ground_truth: bool = True
-            If set to True, will return all tasks
-            that have been completed in your workflow.
-
-        concurrency: int = 10
-            The number of requests that will be made in parallel.
-
-        name: Optional[str] = None
-            If present, will return the task with task_id == name.
-            If no match found, will return the task with task name == name
-
-        Returns
-        -----------
-        List[Dict]
-            [{"taskId": str, "name": str, "createdAt": str, "currentStageName": str}]
-        """
-        logger.warning(
-            "`Export.search_tasks` method has been deprecated and will be removed "
-            + "in a future release. Please use `Export.list_tasks` method instead."
-        )
-        my_iter = PaginationIterator(
-            partial(  # type: ignore
-                self.context.export.task_search,
-                self.org_id,
-                self.project_id,
-                self.output_stage_name if only_ground_truth else None,
-                name,
-                None,
-                True,
-            ),
-            concurrency,
-        )
-
-        with tqdm.tqdm(my_iter, unit=" datapoints") as progress:
-            datapoints = [
-                {
-                    "taskId": task["taskId"],
-                    "name": task["datapoint"]["name"],
-                    "createdAt": task["createdAt"],
-                    "currentStageName": task["currentStageName"],
-                }
-                for task in progress
-                if (task.get("datapoint", {}) or {}).get("name")
-                and (not only_ground_truth or task["currentStageName"] == "END")
-            ]
-
-        return datapoints
+        loop = asyncio.get_event_loop()
+        for datapoint in datapoints:
+            task: Dict = loop.run_until_complete(
+                self.export_nifti_label_data(  # type: ignore
+                    datapoint,
+                    taxonomy,
+                    task_file,
+                    image_dir,
+                    segmentation_dir,
+                    old_format,
+                    no_consensus,
+                    color_map,
+                    with_files,
+                    dicom_to_nifti,
+                    png,
+                    rt_struct,
+                    True,
+                )
+            )
+            yield task
 
     def list_tasks(
         self,
@@ -1058,7 +941,7 @@ class Export:
         user_id: Optional[str] = None,
         task_id: Optional[str] = None,
         task_name: Optional[str] = None,
-    ) -> List[Dict]:
+    ) -> Iterator[Dict]:
         """
         Search tasks based on multiple queries for a project.
         This function returns minimal meta-data about the queried tasks.
@@ -1095,8 +978,8 @@ class Export:
 
         Returns
         -----------
-        List[Dict]
-            [{
+        Iterator[Dict]
+            >>> [{
                 "taskId": str,
                 "name": str,
                 "createdAt": str,
@@ -1177,54 +1060,46 @@ class Export:
             limit,
         )
 
-        tasks: List[Dict] = []
-        with tqdm.tqdm(my_iter, unit=" datapoints") as progress:
-            for task in progress:
-                datapoint = task["datapoint"] or {}
-                task_obj = {
-                    "taskId": task["taskId"],
-                    "name": datapoint.get("name"),
-                    "createdAt": task["createdAt"],
-                    "currentStageName": task["currentStageName"],
-                }
+        for task in my_iter:
+            datapoint = task["datapoint"] or {}
+            task_obj = {
+                "taskId": task["taskId"],
+                "name": datapoint.get("name"),
+                "createdAt": task["createdAt"],
+                "currentStageName": task["currentStageName"],
+            }
 
-                if datapoint.get("createdByEntity"):
-                    task_obj["createdBy"] = from_rb_assignee(
-                        datapoint["createdByEntity"]
-                    )
-                if task["priority"]:
-                    task_obj["priority"] = task["priority"]
-                if datapoint.get("metaData"):
-                    task_obj["metaData"] = json.loads(datapoint["metaData"])
+            if datapoint.get("createdByEntity"):
+                task_obj["createdBy"] = from_rb_assignee(datapoint["createdByEntity"])
+            if task["priority"]:
+                task_obj["priority"] = task["priority"]
+            if datapoint.get("metaData"):
+                task_obj["metaData"] = json.loads(datapoint["metaData"])
 
-                if isinstance(datapoint.get("seriesInfo"), list):
-                    series_list = []
-                    for series in datapoint["seriesInfo"]:
-                        series_obj = {}
-                        if series["name"]:
-                            series_obj["name"] = series["name"]
-                        if series["metaData"]:
-                            series_obj["metaData"] = json.loads(series["metaData"])
-                        series_list.append(series_obj)
-                    if any(series for series in series_list):
-                        task_obj["series"] = series_list
+            if isinstance(datapoint.get("seriesInfo"), list):
+                series_list = []
+                for series in datapoint["seriesInfo"]:
+                    series_obj = {}
+                    if series["name"]:
+                        series_obj["name"] = series["name"]
+                    if series["metaData"]:
+                        series_obj["metaData"] = json.loads(series["metaData"])
+                    series_list.append(series_obj)
+                if any(series for series in series_list):
+                    task_obj["series"] = series_list
 
-                assignees = [
-                    from_rb_assignee(assignee)
-                    for assignee in (
-                        (task["currentStageSubTask"] or {}).get(
-                            "consensusAssignees", []
-                        )
-                        or []
-                    )
-                ]
+            assignees = [
+                from_rb_assignee(assignee)
+                for assignee in (
+                    (task["currentStageSubTask"] or {}).get("consensusAssignees", [])
+                    or []
+                )
+            ]
 
-                if assignees:
-                    task_obj["assignees"] = assignees
+            if assignees:
+                task_obj["assignees"] = assignees
 
-                tasks.append(task_obj)
-
-        return tasks
+            yield task_obj
 
     def get_task_events(
         self,
@@ -1262,7 +1137,7 @@ class Export:
         Returns
         -----------
         List[Dict]
-            [{"taskId": str, "currentStageName": str, "events": List[Dict]}]
+            >>> [{"taskId": str, "currentStageName": str, "events": List[Dict]}]
         """
         members = self.context.project.get_members(self.org_id, self.project_id)
         users = {}

--- a/redbrick/organization/__init__.py
+++ b/redbrick/organization/__init__.py
@@ -231,6 +231,30 @@ class RBOrganization:
 
         return tasks
 
+    def create_taxonomy(
+        self,
+        name: str,
+        study_classify: Optional[List[Dict]] = None,
+        series_classify: Optional[List[Dict]] = None,
+        instance_classify: Optional[List[Dict]] = None,
+        object_types: Optional[List[Dict]] = None,
+    ) -> None:
+        """
+        Create a Taxonomy V2.
+
+        Format reference for categories and attributes objects:
+        https://docs.redbrickai.com/python-sdk/sdk-overview/reference#taxonomy-objects
+        """
+        if self.context.project.create_taxonomy(
+            self.org_id,
+            name,
+            study_classify,
+            series_classify,
+            instance_classify,
+            object_types,
+        ):
+            logger.info(f"Successfully created taxonomy: {name}")
+
     def create_taxonomy_new(
         self,
         name: str,
@@ -245,18 +269,13 @@ class RBOrganization:
         Format reference for categories and attributes objects:
         https://docs.redbrickai.com/python-sdk/sdk-overview/reference#taxonomy-objects
         """
-        if self.context.project.create_taxonomy_new(
-            self.org_id,
-            name,
-            study_classify,
-            series_classify,
-            instance_classify,
-            object_types,
-        ):
-            logger.info(f"Successfully created taxonomy: {name}")
+        logger.warning("Deprecated: Please use `create_taxonomy()`")
+        self.create_taxonomy(
+            name, study_classify, series_classify, instance_classify, object_types
+        )
 
     def get_taxonomy(
-        self, tax_id: Optional[str] = None, name: Optional[str] = None
+        self, name: Optional[str] = None, tax_id: Optional[str] = None
     ) -> Dict:
         """Get a taxonomy created in your organization."""
         taxonomy = self.context.project.get_taxonomy(self._org_id, tax_id, name)

--- a/redbrick/organization/__init__.py
+++ b/redbrick/organization/__init__.py
@@ -219,6 +219,7 @@ class RBOrganization:
         with tqdm(my_iter, unit=" tasks") as progress:
             tasks = [
                 {
+                    "orgId": self._org_id,
                     "projectId": task["project"]["projectId"],
                     "taskId": task["taskId"],
                     "completedBy": task["user"]["email"],

--- a/redbrick/repo/export.py
+++ b/redbrick/repo/export.py
@@ -131,7 +131,7 @@ class ExportRepo(ExportControllerInterface):
     ) -> Dict:
         """Get input labels."""
         query = """
-        query dataPoint(
+        query dataPointSDK(
             $orgId: UUID!
             $dpId: UUID!
             $name: String!
@@ -177,7 +177,7 @@ class ExportRepo(ExportControllerInterface):
             $first: Int
             $after: String
         ) {{
-            genericTasks(
+            genericTasksSDK(
                 orgId: $orgId
                 projectId: $projectId
                 stageName: $stageName
@@ -234,7 +234,7 @@ class ExportRepo(ExportControllerInterface):
     ) -> List[Optional[str]]:
         """Presign download items."""
         query = """
-        query presignItems(
+        query presignItemsSDK(
             $orgId: UUID!
             $storageId: UUID!
             $items: [String]!
@@ -260,7 +260,7 @@ class ExportRepo(ExportControllerInterface):
     ) -> Tuple[List[Dict], Optional[str]]:
         """Get task events."""
         query_string = """
-        query taskEvents(
+        query taskEventsSDK(
             $orgId: UUID!
             $projectId: UUID!
             $stageName: String
@@ -359,3 +359,58 @@ class ExportRepo(ExportControllerInterface):
         task_events = result.get("tasksPaged", {}) or {}
         entries: List[Dict] = task_events.get("entries", []) or []
         return entries, task_events.get("cursor")
+
+    def active_time(
+        self,
+        org_id: str,
+        project_id: str,
+        stage_name: str,
+        task_id: Optional[str] = None,
+        first: int = 100,
+        after: Optional[str] = None,
+    ) -> Tuple[List[Dict], Optional[str]]:
+        """Get task active time."""
+        query_string = """
+        query taskActiveTimeSDK(
+            $orgId: UUID!
+            $projectId: UUID!
+            $stageName: String!
+            $taskId: String
+            $first: Int
+            $after: String
+        ) {
+            taskActiveTime(
+                orgId: $orgId
+                projectId: $projectId
+                stageName: $stageName
+                taskId: $taskId
+                first: $first
+                after: $after
+            ) {
+                entries {
+                    taskId
+                    user {
+                        userId
+                    }
+                    timeSpent
+                    cycle
+                    date
+                }
+                cursor
+            }
+        }
+        """
+
+        query_variables = {
+            "orgId": org_id,
+            "projectId": project_id,
+            "stageName": stage_name,
+            "taskId": task_id,
+            "first": first,
+            "after": after,
+        }
+
+        result = self.client.execute_query(query_string, query_variables, False)
+        task_times = result.get("taskActiveTime", {}) or {}
+        entries: List[Dict] = task_times.get("entries", []) or []
+        return entries, task_times.get("cursor")

--- a/redbrick/repo/export.py
+++ b/redbrick/repo/export.py
@@ -168,7 +168,7 @@ class ExportRepo(ExportControllerInterface):
     ) -> Tuple[List[Dict], Optional[str]]:
         """Task search."""
         query_string = f"""
-        query tasksList(
+        query tasksListSDK(
             $orgId: UUID!
             $projectId: UUID!
             $stageName: String
@@ -177,7 +177,7 @@ class ExportRepo(ExportControllerInterface):
             $first: Int
             $after: String
         ) {{
-            genericTasksSDK(
+            genericTasks(
                 orgId: $orgId
                 projectId: $projectId
                 stageName: $stageName
@@ -190,6 +190,7 @@ class ExportRepo(ExportControllerInterface):
                     taskId
                     currentStageName
                     createdAt
+                    updatedAt
                     priority
                     datapoint {{
                         {datapoint_shard(not only_meta_data, not only_meta_data)}

--- a/redbrick/repo/labeling.py
+++ b/redbrick/repo/labeling.py
@@ -18,7 +18,7 @@ class LabelingRepo(LabelingControllerInterface):
     ) -> List[Dict]:
         """Get labeling tasks."""
         query = """
-        mutation assignLabelingTasks(
+        mutation assignLabelingTasksSDK(
             $orgId: UUID!
             $projectId: UUID!
             $stageName: String!
@@ -126,7 +126,7 @@ class LabelingRepo(LabelingControllerInterface):
     ) -> None:
         """Put Labeling results."""
         query = """
-        mutation putTaskAndLabels(
+        mutation putTaskAndLabelsSDK(
             $orgId: UUID!
             $projectId: UUID!
             $stageName: String!
@@ -173,7 +173,7 @@ class LabelingRepo(LabelingControllerInterface):
     ) -> None:
         """Put labeling result for task."""
         query = """
-        mutation putLabelingTask(
+        mutation putLabelingTaskSDK(
             $orgId: UUID!
             $projectId: UUID!
             $stageName: String!
@@ -209,7 +209,7 @@ class LabelingRepo(LabelingControllerInterface):
     ) -> None:
         """Put review result for task."""
         query = """
-        mutation putReviewTask(
+        mutation putReviewTaskSDK(
             $orgId: UUID!
             $projectId: UUID!
             $stageName: String!
@@ -252,7 +252,7 @@ class LabelingRepo(LabelingControllerInterface):
     ) -> List[Dict]:
         """Assign tasks to specified email or current API key."""
         query_string = """
-        mutation assignTasksMultipleUsers(
+        mutation assignTasksMultipleUsersSDK(
             $orgId: UUID!
             $projectId: UUID!
             $taskIds: [UUID!]!
@@ -298,7 +298,7 @@ class LabelingRepo(LabelingControllerInterface):
     ) -> None:
         """Move groundtruth task back to start."""
         query = """
-        mutation moveTaskToStart(
+        mutation moveTaskToStartSDK(
             $orgId: UUID!
             $projectId: UUID!
             $taskId: UUID!

--- a/redbrick/repo/project.py
+++ b/redbrick/repo/project.py
@@ -22,7 +22,7 @@ class ProjectRepo(ProjectRepoInterface):
         Raise an exception if project does not exist.
         """
         query = f"""
-            query sdkGetProjectName($orgId: UUID!, $projectId: UUID!) {{
+            query sdkGetProjectNameSDK($orgId: UUID!, $projectId: UUID!) {{
                 project(orgId: $orgId, projectId: $projectId) {{
                     {PROJECT_SHARD}
                 }}
@@ -38,7 +38,7 @@ class ProjectRepo(ProjectRepoInterface):
     def get_stages(self, org_id: str, project_id: str) -> List[Dict]:
         """Get stages."""
         query = """
-            query sdkGetStages($orgId: UUID!, $projectId: UUID!){
+            query sdkGetStagesSDK($orgId: UUID!, $projectId: UUID!){
                 stages(orgId: $orgId, projectId: $projectId){
                     stageName
                     brickName
@@ -61,7 +61,7 @@ class ProjectRepo(ProjectRepoInterface):
     ) -> Dict:
         """Create a project and return project_id."""
         query = """
-            mutation createProjectSimple(
+            mutation createProjectSimpleSDK(
                 $orgId: UUID!
                 $name: String!
                 $stages: [StageInputSimple!]!
@@ -361,7 +361,7 @@ class ProjectRepo(ProjectRepoInterface):
     def get_current_user(self) -> Dict:
         """Get current user."""
         query_string = """
-        query currentUser {
+        query currentUserSDK {
             me {
                 userId
             }

--- a/redbrick/repo/project.py
+++ b/redbrick/repo/project.py
@@ -215,48 +215,6 @@ class ProjectRepo(ProjectRepoInterface):
         self,
         org_id: str,
         name: str,
-        categories: List[Dict],
-        attributes: Optional[List[Dict]],
-        task_categories: Optional[List[Dict]],
-        task_attributes: Optional[List[Dict]],
-    ) -> bool:
-        """Create taxonomy."""
-        query_string = """
-        mutation createTaxonomySDK(
-            $orgId: UUID!
-            $name: String!
-            $categories: [CategoryRootInput!]!
-            $attributes: [AttributeInput]
-            $taskCategories: [CategoryRootInput!]
-            $taskAttributes: [AttributeInput!]
-        ) {
-            createTaxonomy(
-                orgId: $orgId
-                name: $name
-                categories: $categories
-                attributes: $attributes
-                taskCategories: $taskCategories
-                taskAttributes: $taskAttributes
-            ) {
-                ok
-            }
-        }
-        """
-        query_variables = {
-            "orgId": org_id,
-            "name": name,
-            "categories": categories,
-            "attributes": attributes,
-            "taskCategories": task_categories,
-            "taskAttributes": task_attributes,
-        }
-        result = self.client.execute_query(query_string, query_variables, False)
-        return bool(result and result.get("createTaxonomy", {}).get("ok"))
-
-    def create_taxonomy_new(
-        self,
-        org_id: str,
-        name: str,
         study_classify: Optional[List[Dict]],
         series_classify: Optional[List[Dict]],
         instance_classify: Optional[List[Dict]],

--- a/redbrick/repo/upload.py
+++ b/redbrick/repo/upload.py
@@ -102,7 +102,7 @@ class UploadRepo(UploadControllerInterface):
     ) -> Dict:
         """Update items in a datapoint."""
         query_string = """
-            mutation updateTaskItems(
+            mutation updateTaskItemsSDK(
                 $orgId: UUID!
                 $projectId: UUID!
                 $storageId: UUID!
@@ -142,7 +142,7 @@ class UploadRepo(UploadControllerInterface):
     ) -> List[Dict[Any, Any]]:
         """Return presigned URLs to upload files."""
         query_string = """
-            query itemsUploadPresign(
+            query itemsUploadPresignSDK(
                 $orgId:UUID!,
                 $projectId: UUID!,
                 $files: [String]!,
@@ -247,7 +247,7 @@ class UploadRepo(UploadControllerInterface):
     ) -> str:
         """Generate direct upload items list."""
         query_string = """
-            query generateItemsList(
+            query generateItemsListSDK(
                 $importType: ImportType!
                 $files: [String]!
                 $groupedByStudy: Boolean!
@@ -283,7 +283,7 @@ class UploadRepo(UploadControllerInterface):
     ) -> Dict:
         """Validate and convert tasks format."""
         query_string = """
-        query validateAndConvertToImportFormat(
+        query validateAndConvertToImportFormatSDK(
             $original: String!
             $convert: Boolean
             $storageId: UUID
@@ -321,7 +321,7 @@ class UploadRepo(UploadControllerInterface):
     ) -> Dict:
         """Import tasks from another project in the same workspace."""
         query_string = """
-            mutation importTasksFromWorkspace(
+            mutation importTasksFromWorkspaceSDK(
                 $orgId: UUID!
                 $projectId: UUID!
                 $sourceProjectId: UUID!

--- a/redbrick/repo/workspace.py
+++ b/redbrick/repo/workspace.py
@@ -19,7 +19,7 @@ class WorkspaceRepo(WorkspaceRepoInterface):
         Raise an exception if workspace does not exist.
         """
         query = """
-            query sdkGetWorkspace($orgId: UUID!, $workspaceId: UUID!){
+            query sdkGetWorkspaceSDK($orgId: UUID!, $workspaceId: UUID!){
                 workspace(orgId: $orgId, workspaceId: $workspaceId){
                     orgId
                     workspaceId
@@ -45,7 +45,7 @@ class WorkspaceRepo(WorkspaceRepoInterface):
         Raise an exception if workspace already exists.
         """
         query = """
-            mutation sdkCreateWorkspace($orgId: UUID!, $workspaceName: String!){
+            mutation sdkCreateWorkspaceSDK($orgId: UUID!, $workspaceName: String!){
                 createWorkspace(orgId: $orgId, workspaceName: $workspaceName){
                     orgId
                     workspaceId

--- a/redbrick/upload/public.py
+++ b/redbrick/upload/public.py
@@ -378,7 +378,7 @@ class Upload:
         Returns
         ------------
         List[Dict]
-            [
+            >>> [
                 {
                     "presignedUrl: "...", # url to upload to
                     "filePath": "..." # remote file path

--- a/redbrick/utils/dicom.py
+++ b/redbrick/utils/dicom.py
@@ -290,6 +290,9 @@ async def convert_nii_to_rtstruct(
                 for category in categories
             }
             rtstruct = RTStructBuilder.create_new(dicom_series_path=dicom_series_path)
+            rtstruct.ds.InstitutionName = "RedBrick AI"
+            rtstruct.ds.Manufacturer = "RedBrick AI"
+            rtstruct.ds.ManufacturerModelName = "redbrick-sdk"
             for nifti_file in nifti_files:
                 img: Nifti1Image = nib_load(nifti_file)  # type: ignore
 

--- a/redbrick/utils/rb_event_utils.py
+++ b/redbrick/utils/rb_event_utils.py
@@ -1,18 +1,8 @@
 """Utilities for working with event objects."""
-from typing import Optional, List, Dict
+from typing import List, Dict
 
 from redbrick.common.enums import TaskEventTypes
-
-
-def user_format(user: Optional[str], users: Dict[str, str]) -> Optional[str]:
-    """User format."""
-    if not user:
-        return user
-    if user.startswith("RB:"):
-        return "System"
-    if user.startswith("API:"):
-        return "API Key"
-    return users.get(user, user)
+from redbrick.utils.rb_label_utils import user_format
 
 
 def comment_format(comment: Dict, users: Dict[str, str]) -> Dict:


### PR DESCRIPTION
## Added:
- Support to export segmentations in DICOM RT-Struct format using `--rt-struct` in redbrick export / `rt_struct: bool` in Export.export_tasks
- Export.get_active_time
```
def get_active_time(
    self,
    *,
    stage_name: str,
    task_id: Optional[str] = None,
    concurrency: int = 100,
) -> Iterator[Dict]:
    """Get active time spent on tasks for labeling/reviewing.
    Parameters
    -----------
    stage_name: str
        Stage for which to return the time info.

    task_id: Optional[str] = None
        If set, will return info for the given task in the given stage.

    concurrency: int = 100
        Request batch size.

    Returns
    -----------
    Iterator[Dict]
        >>> [{
            "orgId": string,
            "projectId": string,
            "stageName": string,
            "taskId": string,
            "completedBy": string,
            "timeSpent": number,  # In milliseconds
            "completedAt": datetime,
            "cycle": number  # Task cycle
        }]
    """
```
- Export.list_tasks added param
```
completed_at: Optional[Tuple[Optional[float], Optional[float]]] = None
If present, will return tasks that were completed in the given time range.
The tuple contains the `from` and `to` timestamps respectively.
```

## Changed:
- Renamed RBOrganization.create_taxonomy_new -> RBOrganization.create_taxonomy
- Export.export_tasks now returns Iterator[Dict]
- Export.list_tasks now returns Iterator[Dict]
- Export.get_task_events now returns Iterator[Dict]
- Unified all `user` entities across exports to email of user.

## Removed:
- Export.search_tasks
- Export.redbrick_nifti
- Labeling.get_tasks
- Labeling.get_task_queue
- Labeling.assign_tasks (removed current_user param)