### PR TITLE
Ignore-downloading-the-AltaDB-datapoints-in-export-command

### DIFF
--- a/redbrick/export/public.py
+++ b/redbrick/export/public.py
@@ -354,12 +354,11 @@ class Export:
 
             to_presign = []
             local_files = []
-            def filter_out_altadb_items(items_list: List[str]) -> List[str]:
-                return [item for item in items_list if not item.startswith("altadb://")]
 
             if ignore_altadb:
                 items_lists = [
-                    filter_out_altadb_items(items_list) for items_list in items_lists
+                    self.filter_out_altadb_items(items_list)
+                    for items_list in items_lists
                 ]
             for series_dir, paths in zip(series_dirs, items_lists):
                 file_names = [
@@ -1352,3 +1351,7 @@ class Export:
                     "completedAt": task["date"],
                     "cycle": task["cycle"],
                 }
+
+    def filter_out_altadb_items(self, items_list: List[str]) -> List[str]:
+        """Filter out altadb items."""
+        return [item for item in items_list if not item.startswith("altadb://")]

--- a/redbrick/export/public.py
+++ b/redbrick/export/public.py
@@ -355,13 +355,12 @@ class Export:
             local_files = []
 
             if any(self.contains_altadb_item(item_list) for item_list in items_lists):
-                logger.warning(
-                    f"Task {task.get('taskId')} contains items from AltADB. Download ignored for the task."
-                )
                 # Delete if the task directory is empty
                 if os.path.exists(task_dir) and not os.listdir(task_dir):
                     os.rmdir(task_dir)
-                return task, []
+                raise Exception(
+                    f"Task {task.get('taskId')} contains items from AltADB. Download ignored for the task."
+                )
 
             for series_dir, paths in zip(series_dirs, items_lists):
                 file_names = [

--- a/redbrick/export/public.py
+++ b/redbrick/export/public.py
@@ -301,6 +301,7 @@ class Export:
         taxonomy: Taxonomy,
         rt_struct: bool,
         semantic_mask: bool,
+        ignore_altadb: bool = True,
     ) -> Tuple[TypeTask, List[str]]:
         # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         path_pattern = re.compile(r"[^\w.]+")
@@ -353,6 +354,13 @@ class Export:
 
             to_presign = []
             local_files = []
+            def filter_out_altadb_items(items_list: List[str]) -> List[str]:
+                return [item for item in items_list if not item.startswith("altadb://")]
+
+            if ignore_altadb:
+                items_lists = [
+                    filter_out_altadb_items(items_list) for items_list in items_lists
+                ]
             for series_dir, paths in zip(series_dirs, items_lists):
                 file_names = [
                     re.sub(

--- a/redbrick/export/public.py
+++ b/redbrick/export/public.py
@@ -361,7 +361,7 @@ class Export:
                 # Delete if the task directory is empty
                 if os.path.exists(task_dir) and not os.listdir(task_dir):
                     os.rmdir(task_dir)
-                return task, series_dirs
+                return task, []
 
             for series_dir, paths in zip(series_dirs, items_lists):
                 file_names = [

--- a/redbrick/export/public.py
+++ b/redbrick/export/public.py
@@ -356,7 +356,7 @@ class Export:
 
             if any(self.contains_altadb_item(item_list) for item_list in items_lists):
                 # Delete if the task directory is empty
-                if os.path.exists(task_dir) and not os.listdir(task_dir):
+                if os.path.isdir(task_dir) and not os.listdir(task_dir):
                     os.rmdir(task_dir)
                 raise Exception(
                     f"Task {task.get('taskId')} contains items from AltADB. Download ignored for the task."


### PR DESCRIPTION
 There is some error in downloading the AltaDB files. For now, we're choosing to ignore the AltaDB images for downloading