### PR TITLE
Update metadata along for tasks

### DIFF
--- a/redbrick/common/upload.py
+++ b/redbrick/common/upload.py
@@ -44,6 +44,7 @@ class UploadControllerInterface(ABC):
         task_id: str,
         items: List[str],
         series_info: Optional[List[Dict]] = None,
+        meta_data: Optional[Dict[str, str]] = None,
     ) -> Dict:
         """Update items in a datapoint."""
 

--- a/redbrick/repo/upload.py
+++ b/redbrick/repo/upload.py
@@ -146,7 +146,7 @@ class UploadRepo(UploadControllerInterface):
             "seriesInfo": series_info,
         }
         if meta_data:
-            query_variables["metaData"] = json.dumps(meta_data, indent=0)
+            query_variables["metaData"] = json.dumps(meta_data)
         response = await self.client.execute_query_async(
             aio_client, query_string, query_variables
         )

--- a/redbrick/repo/upload.py
+++ b/redbrick/repo/upload.py
@@ -109,6 +109,7 @@ class UploadRepo(UploadControllerInterface):
         task_id: str,
         items: List[str],
         series_info: Optional[List[Dict]] = None,
+        meta_data: Optional[Dict[str, str]] = None,
     ) -> Dict:
         """Update items in a datapoint."""
         query_string = """
@@ -119,6 +120,7 @@ class UploadRepo(UploadControllerInterface):
                 $taskId: UUID!
                 $items: [String!]!
                 $seriesInfo: [SeriesInfoInput!]
+                $metaData: String
             ) {
                 updateTaskItems(
                     orgId: $orgId
@@ -127,6 +129,7 @@ class UploadRepo(UploadControllerInterface):
                     taskId: $taskId
                     items: $items
                     seriesInfo: $seriesInfo
+                    metaData: $metaData
                 ) {
                     ok
                     message
@@ -142,6 +145,8 @@ class UploadRepo(UploadControllerInterface):
             "items": items,
             "seriesInfo": series_info,
         }
+        if meta_data:
+            query_variables["metaData"] = json.dumps(meta_data, indent=0)
         response = await self.client.execute_query_async(
             aio_client, query_string, query_variables
         )


### PR DESCRIPTION
#### Issue
Sending task `metaData` along with the task details is not updating the `metaData` in the backend.

------------
#### Diagnosis
The `metaData` field was not being sent to the API.

------------
#### Fix
Also send the `metaData` field for the task.
