### PR TITLE
Improve processing time of process_nifti_upload

### DIFF
--- a/redbrick/utils/dicom.py
+++ b/redbrick/utils/dicom.py
@@ -457,7 +457,6 @@ async def process_nifti_upload(
                         f"Each instance must have a unique file if binary_mask is True: '{file}' ({instance_numbers})"
                     )
                     return None, {}
-            files = sorted(files, key=lambda f: reverse_masks[f][0])
 
         try:
             base_img = nib_load(files[0])
@@ -486,7 +485,7 @@ async def process_nifti_upload(
                         "Instance IDs in segmentation file(s) and segmentMap do not match.\n"
                         + f"Segmentation file(s) have instances: {actual_instance_numbers} and "
                         + f"segmentMap has instances: {expected_instance_numbers}\n"
-                        + f"Segmentation file: {files[0]}"
+                        + f"Segmentation file: {file}"
                     )
 
             if binary_mask:

--- a/redbrick/utils/dicom.py
+++ b/redbrick/utils/dicom.py
@@ -466,11 +466,12 @@ async def process_nifti_upload(
             ):
                 return None, {}
 
-            base_data = base_img.get_fdata(caching="unchanged")
-
             if base_img.get_data_dtype() != numpy.uint16:
-                base_img.set_data_dtype(numpy.uint16)
+                base_data = base_img.get_fdata(caching="unchanged")
                 base_data = numpy.round(base_data).astype(numpy.uint16)  # type: ignore
+                base_img.set_data_dtype(numpy.uint16)
+            else:
+                base_data = numpy.asanyarray(base_img.dataobj, dtype=numpy.uint16)
 
             if base_data.ndim != 3:
                 return None, {}
@@ -507,9 +508,11 @@ async def process_nifti_upload(
                 ):
                     return None, {}
 
-                data = img.get_fdata(caching="unchanged")
                 if img.get_data_dtype() != numpy.uint16:
+                    data = img.get_fdata(caching="unchanged")
                     data = numpy.round(data).astype(numpy.uint16)  # type: ignore
+                else:
+                    data = numpy.asanyarray(img.dataobj, dtype=numpy.uint16)
 
                 # Keep track of the instance numbers that we expect and see in the current
                 # mask, to validate after merging.

--- a/tests/test_utils/test_dicom.py
+++ b/tests/test_utils/test_dicom.py
@@ -480,20 +480,16 @@ async def test_process_nifti_upload(tmpdir, nifti_instance_files_png):
     masks = {_mask_inst_id: _mask}
     label_validate = True
 
-    with patch.object(
-        dicom, "config_path", return_value=str(tmpdir)
-    ) as mock_config_path:
-        result, group_map = await dicom.process_nifti_upload(
-            files,
-            instances,
-            binary_mask,
-            semantic_mask,
-            png_mask,
-            masks,
-            label_validate,
-        )
+    result, group_map = await dicom.process_nifti_upload(
+        files,
+        instances,
+        binary_mask,
+        semantic_mask,
+        png_mask,
+        masks,
+        label_validate,
+    )
 
-    mock_config_path.assert_called_once()
     assert isinstance(result, str) and result.endswith("label.nii.gz")
     assert os.path.isfile(result)
     assert isinstance(group_map, dict)


### PR DESCRIPTION
The function `process_nifti_upload` takes exceptionally long to run, especially over binary masks. For example:
- 6 binary masks of dimension (512x512x812) takes ~180s to process
- 2 non-binary masks (with a total of 6 instances) of dimension (512x512x812) takes ~55s to process

With the improvements to the function in this PR, the times go down to ~30s and ~10s for the above examples (respectively).

The main improvements come from:
- Ensuring that each nifti file is only loaded once
- Working over the non-zero indices of each file (since segmentation masks tend to be quite sparse, this gives a large improvement)
- Instead of iterating over each index (i, j, k), we group together the indices that belong to the same group and update them all at once
- Avoid pre-converting binary masks (we can just set the instance number for all non-zero indices when processing that file)

I have added detailed comments to explain the updated logic.

There was also a bug with the logic that decides to convert the base image data to a uint8 array that I fixed.