### PR TITLE
Fix bug in process_nifti_upload

### DIFF
--- a/redbrick/__init__.py
+++ b/redbrick/__init__.py
@@ -30,7 +30,7 @@ from .config import config
 from .version_check import version_check
 
 
-__version__ = "2.19.5"
+__version__ = "2.19.6"
 
 # windows event loop close bug https://github.com/encode/httpx/issues/914#issuecomment-622586610
 try:

--- a/redbrick/utils/dicom.py
+++ b/redbrick/utils/dicom.py
@@ -494,7 +494,7 @@ async def process_nifti_upload(
                 instance_number = reverse_masks[files[0]][0]
                 base_data[numpy.nonzero(base_data)] = instance_number
                 used_instances.add(instance_number)
-            else:
+            elif label_validate:
                 non_zero_base_data = base_data[numpy.nonzero(base_data)]
                 used_instances = (
                     set(x.item() for x in numpy.unique(non_zero_base_data).round())
@@ -572,7 +572,7 @@ async def process_nifti_upload(
                                 f"Instance ID: {base_v} is not present in segmentMap"
                             )
 
-            if used_instances != instance_keys:
+            if label_validate and used_instances != instance_keys:
                 raise ValueError(
                     "Instance IDs in segmentation file(s) and segmentMap do not match.\n"
                     + f"Segmentation file(s) have instances: {used_instances} and "

--- a/tests/test_utils/test_dicom.py
+++ b/tests/test_utils/test_dicom.py
@@ -500,6 +500,9 @@ async def test_process_nifti_upload(tmpdir, nifti_instance_files_png):
     assert set(group_map) == instances
     assert isinstance(group_map, dict)
 
+    # Ensure no group IDs has the same value any instance ID
+    assert set().union(*group_map.values()).intersection(instances) == set()
+
 
 @pytest.mark.unit
 @pytest.mark.asyncio

--- a/tests/test_utils/test_dicom.py
+++ b/tests/test_utils/test_dicom.py
@@ -503,6 +503,23 @@ async def test_process_nifti_upload(tmpdir, nifti_instance_files_png):
     # Ensure no group IDs has the same value any instance ID
     assert set().union(*group_map.values()).intersection(instances) == set()
 
+    # Verify that we can produce the expected masks from the label file and group map
+    expected_masks = {
+        1: np.array([[[1], [1], [1]], [[1], [1], [1]], [[1], [1], [1]]]),
+        2: np.array([[[0], [0], [1]], [[1], [1], [0]], [[0], [0], [0]]]),
+        3: np.array([[[1], [0], [0]], [[0], [0], [1]], [[0], [1], [0]]]),
+        4: np.array([[[0], [0], [0]], [[0], [0], [0]], [[0], [0], [1]]]),
+        5: np.array([[[0], [1], [0]], [[0], [1], [0]], [[0], [0], [1]]]),
+        9: np.array([[[0], [0], [0]], [[0], [0], [0]], [[1], [0], [0]]]),
+    }
+    global_mask = np.asanyarray(nib.load(result).dataobj, np.uint8)
+    for instance_id in instances:
+        selector = global_mask == instance_id
+        for group_id in group_map.get(instance_id, []):
+            selector = np.logical_or(selector, global_mask == group_id)
+        mask = selector.astype(np.uint8)
+        assert np.all(mask == expected_masks[instance_id])
+
 
 @pytest.mark.unit
 @pytest.mark.asyncio


### PR DESCRIPTION
In the recent update, there was a bug introduced that meant group
numbers were conflicting with instance numbers. This was because we
subtracted the instance_keys from the instance_pool before populating
the instance_keys variable.

I have updated the unit test to check for this condition.

Additionally, I have added a minor optimization to the setting of
used_instances from the base_data to only call unique on non-zero
values. This saves a few seconds on large sparse segmentations.