### PR TITLE
Fix license check with tools like liccheck

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@
 name = "redbrick-sdk"
 description = "RedBrick platform Python SDK!"
 readme = "README.md"
+license.file = "LICENSE"
 dynamic = ["version"]
 requires-python = ">=3.9,<3.14"
 keywords = ["redbrick"]


### PR DESCRIPTION
Currently the LICENSE file is not referenced in the `pyproject.toml`, therefore automatic license checking (e.g. with `liccheck`) won't recognize the license. This PR fixes this issue